### PR TITLE
update swc core to 0.75

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "ast_node"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f26ba4b3f1c2776bdacf6d0b96fce173155f2da6ace0202e39e7041ae33083"
+checksum = "52f7fd7740c5752c16281a1c1f9442b1e69ba41738acde85dc604aaf3ce41890"
 dependencies = [
  "pmutil",
  "proc-macro2",
@@ -141,6 +141,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c70beb79cbb5ce9c4f8e20849978f34225931f665bb49efa6982875a4d5facb3"
 
 [[package]]
 name = "block-buffer"
@@ -538,8 +544,9 @@ dependencies = [
  "serde",
  "serde_json",
  "string_cache",
- "swc_atoms",
- "swc_core",
+ "swc_atoms 0.5.3",
+ "swc_core 0.74.6",
+ "swc_core 0.75.20",
  "testing 0.31.43",
 ]
 
@@ -1028,7 +1035,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1037,7 +1044,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1133,7 +1140,7 @@ version = "0.37.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85597d61f83914ddeba6a47b3b8ffe7365107221c2e557ed94426489fefb5f77"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -1401,6 +1408,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "swc_atoms"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "593c2f3e4cea60ddc4179ed731cabebe7eacec209d9e76a3bbcff4b2b020e3f5"
+dependencies = [
+ "once_cell",
+ "rustc-hash",
+ "serde",
+ "string_cache",
+ "string_cache_codegen",
+ "triomphe",
+]
+
+[[package]]
 name = "swc_common"
 version = "0.29.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1421,7 +1442,7 @@ dependencies = [
  "serde",
  "siphasher",
  "string_cache",
- "swc_atoms",
+ "swc_atoms 0.4.43",
  "swc_eq_ignore_macros",
  "swc_visit",
  "termcolor",
@@ -1438,7 +1459,7 @@ checksum = "53e95bf36e3e217431c50eab784c5601bf5f0ed3657aac6bda57748fa4d6103b"
 dependencies = [
  "ahash",
  "anyhow",
- "ast_node 0.9.2",
+ "ast_node 0.9.3",
  "atty",
  "better_scoped_tls",
  "cfg-if",
@@ -1454,7 +1475,38 @@ dependencies = [
  "siphasher",
  "sourcemap",
  "string_cache",
- "swc_atoms",
+ "swc_atoms 0.4.43",
+ "swc_eq_ignore_macros",
+ "swc_visit",
+ "termcolor",
+ "tracing",
+ "unicode-width",
+ "url",
+]
+
+[[package]]
+name = "swc_common"
+version = "0.31.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b557014d62318e08070c2a3d5eb0278ff73749dd69db53c39a4de4bcd301d6a"
+dependencies = [
+ "ahash",
+ "ast_node 0.9.3",
+ "atty",
+ "better_scoped_tls",
+ "cfg-if",
+ "either",
+ "from_variant",
+ "new_debug_unreachable",
+ "num-bigint",
+ "once_cell",
+ "parking_lot",
+ "rustc-hash",
+ "serde",
+ "siphasher",
+ "sourcemap",
+ "string_cache",
+ "swc_atoms 0.5.3",
  "swc_eq_ignore_macros",
  "swc_visit",
  "termcolor",
@@ -1470,17 +1522,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e18b78930ecae9f6415393c0c396af455e2a3cda540620f01b28a3e99ce4cc77"
 dependencies = [
  "once_cell",
- "swc_atoms",
+ "swc_atoms 0.4.43",
  "swc_common 0.30.5",
- "swc_ecma_ast",
- "swc_ecma_parser",
- "swc_ecma_transforms_base",
- "swc_ecma_transforms_testing",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.102.5",
+ "swc_ecma_transforms_base 0.125.1",
+ "swc_ecma_transforms_testing 0.128.2",
+ "swc_ecma_utils 0.115.8",
+ "swc_ecma_visit 0.88.5",
  "swc_plugin",
  "swc_plugin_macro",
  "swc_plugin_proxy",
+ "vergen",
+]
+
+[[package]]
+name = "swc_core"
+version = "0.75.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f087f9c1f06bf7b2ad6303bd7362614653e381f3bb3b35f20d658663245e9993"
+dependencies = [
+ "swc_ecma_parser 0.133.8",
+ "swc_ecma_transforms_base 0.126.10",
+ "swc_ecma_transforms_testing 0.129.10",
  "vergen",
 ]
 
@@ -1490,14 +1553,30 @@ version = "0.102.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bc96ac4740ddd7e09baaa153b6cf74e62ed7436d674606c060ea01fd7c20cd0"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "is-macro",
  "num-bigint",
  "rkyv",
  "scoped-tls",
  "string_enum",
- "swc_atoms",
+ "swc_atoms 0.4.43",
  "swc_common 0.30.5",
+ "unicode-id",
+]
+
+[[package]]
+name = "swc_ecma_ast"
+version = "0.103.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5206233430a6763e2759da76cfc596a64250793f70cd94cace1f82fdcc4d702c"
+dependencies = [
+ "bitflags 2.1.0",
+ "is-macro",
+ "num-bigint",
+ "scoped-tls",
+ "string_enum",
+ "swc_atoms 0.5.3",
+ "swc_common 0.31.4",
  "unicode-id",
 ]
 
@@ -1513,9 +1592,28 @@ dependencies = [
  "rustc-hash",
  "serde",
  "sourcemap",
- "swc_atoms",
+ "swc_atoms 0.4.43",
  "swc_common 0.30.5",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.102.5",
+ "swc_ecma_codegen_macros",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_codegen"
+version = "0.138.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd67009c5208689787f9fc59265deaeddad68d3e59da909e8db4615bb8c1d4a9"
+dependencies = [
+ "memchr",
+ "num-bigint",
+ "once_cell",
+ "rustc-hash",
+ "serde",
+ "sourcemap",
+ "swc_atoms 0.5.3",
+ "swc_common 0.31.4",
+ "swc_ecma_ast 0.103.4",
  "swc_ecma_codegen_macros",
  "tracing",
 ]
@@ -1546,9 +1644,29 @@ dependencies = [
  "smallvec",
  "smartstring",
  "stacker",
- "swc_atoms",
+ "swc_atoms 0.4.43",
  "swc_common 0.30.5",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.102.5",
+ "tracing",
+ "typed-arena",
+]
+
+[[package]]
+name = "swc_ecma_parser"
+version = "0.133.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5341644ae5e8d143db12c43dcd06d31138c0dbda7db9db31ce751f0a46a58575"
+dependencies = [
+ "either",
+ "lexical",
+ "num-bigint",
+ "serde",
+ "smallvec",
+ "smartstring",
+ "stacker",
+ "swc_atoms 0.5.3",
+ "swc_common 0.31.4",
+ "swc_ecma_ast 0.103.4",
  "tracing",
  "typed-arena",
 ]
@@ -1572,19 +1690,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b87668640fe6d63ecabaae1805534d1445ff63382ab8961cd623ccdeb1bfbc"
 dependencies = [
  "better_scoped_tls",
- "bitflags",
+ "bitflags 1.3.2",
  "indexmap",
  "once_cell",
  "phf",
  "rustc-hash",
  "serde",
  "smallvec",
- "swc_atoms",
+ "swc_atoms 0.4.43",
  "swc_common 0.30.5",
- "swc_ecma_ast",
- "swc_ecma_parser",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.102.5",
+ "swc_ecma_parser 0.132.6",
+ "swc_ecma_utils 0.115.8",
+ "swc_ecma_visit 0.88.5",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_transforms_base"
+version = "0.126.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907d73e5a76ddb21f33a3f5907c46c9df968ee52ba0d9f8d6ade43e8f06233a3"
+dependencies = [
+ "better_scoped_tls",
+ "bitflags 2.1.0",
+ "indexmap",
+ "once_cell",
+ "phf",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+ "swc_atoms 0.5.3",
+ "swc_common 0.31.4",
+ "swc_ecma_ast 0.103.4",
+ "swc_ecma_parser 0.133.8",
+ "swc_ecma_utils 0.116.8",
+ "swc_ecma_visit 0.89.4",
  "tracing",
 ]
 
@@ -1603,15 +1744,41 @@ dependencies = [
  "sha-1",
  "sourcemap",
  "swc_common 0.30.5",
- "swc_ecma_ast",
- "swc_ecma_codegen",
- "swc_ecma_parser",
+ "swc_ecma_ast 0.102.5",
+ "swc_ecma_codegen 0.137.6",
+ "swc_ecma_parser 0.132.6",
  "swc_ecma_testing",
- "swc_ecma_transforms_base",
- "swc_ecma_utils",
- "swc_ecma_visit",
+ "swc_ecma_transforms_base 0.125.1",
+ "swc_ecma_utils 0.115.8",
+ "swc_ecma_visit 0.88.5",
  "tempfile",
  "testing 0.32.5",
+]
+
+[[package]]
+name = "swc_ecma_transforms_testing"
+version = "0.129.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02fe6a8a1290bbd4fdd9cc1554e3458ffb14e2131936f065bed0a684f89aaf0c"
+dependencies = [
+ "ansi_term",
+ "anyhow",
+ "base64",
+ "hex",
+ "serde",
+ "serde_json",
+ "sha-1",
+ "sourcemap",
+ "swc_common 0.31.4",
+ "swc_ecma_ast 0.103.4",
+ "swc_ecma_codegen 0.138.9",
+ "swc_ecma_parser 0.133.8",
+ "swc_ecma_testing",
+ "swc_ecma_transforms_base 0.126.10",
+ "swc_ecma_utils 0.116.8",
+ "swc_ecma_visit 0.89.4",
+ "tempfile",
+ "testing 0.33.4",
 ]
 
 [[package]]
@@ -1624,10 +1791,28 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "rustc-hash",
- "swc_atoms",
+ "swc_atoms 0.4.43",
  "swc_common 0.30.5",
- "swc_ecma_ast",
- "swc_ecma_visit",
+ "swc_ecma_ast 0.102.5",
+ "swc_ecma_visit 0.88.5",
+ "tracing",
+ "unicode-id",
+]
+
+[[package]]
+name = "swc_ecma_utils"
+version = "0.116.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba86ab0cf8c64043dcc8ac5cb4f438f6e3666ddac58587925ddc2af6be2ed5d1"
+dependencies = [
+ "indexmap",
+ "num_cpus",
+ "once_cell",
+ "rustc-hash",
+ "swc_atoms 0.5.3",
+ "swc_common 0.31.4",
+ "swc_ecma_ast 0.103.4",
+ "swc_ecma_visit 0.89.4",
  "tracing",
  "unicode-id",
 ]
@@ -1639,9 +1824,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67210c9d3bc4cdf6a1b2c69cb4ec77660a37e55e883c5ed9f8bc0e801758334b"
 dependencies = [
  "num-bigint",
- "swc_atoms",
+ "swc_atoms 0.4.43",
  "swc_common 0.30.5",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.102.5",
+ "swc_visit",
+ "tracing",
+]
+
+[[package]]
+name = "swc_ecma_visit"
+version = "0.89.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecb23a4a1d77997f54e9b3a4e68d1441e5e8a25ad1a476bbb3b5a620d6562a86"
+dependencies = [
+ "num-bigint",
+ "swc_atoms 0.5.3",
+ "swc_common 0.31.4",
+ "swc_ecma_ast 0.103.4",
  "swc_visit",
  "tracing",
 ]
@@ -1685,6 +1884,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "swc_error_reporters"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf37dae113d98ec257727dce3d746254a2731abc56e609a6f2efa7cf57806705"
+dependencies = [
+ "anyhow",
+ "miette",
+ "once_cell",
+ "parking_lot",
+ "swc_common 0.31.4",
+]
+
+[[package]]
 name = "swc_macros_common"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1725,7 +1937,7 @@ dependencies = [
  "better_scoped_tls",
  "rkyv",
  "swc_common 0.30.5",
- "swc_ecma_ast",
+ "swc_ecma_ast 0.102.5",
  "swc_trace_macro",
  "tracing",
 ]
@@ -1852,6 +2064,25 @@ dependencies = [
  "serde_json",
  "swc_common 0.30.5",
  "swc_error_reporters 0.14.5",
+ "testing_macros",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "testing"
+version = "0.33.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be7349994b23b7d91beddbfb6d63907651a9d2f6b4e4fa8d2ec65b41094968a"
+dependencies = [
+ "ansi_term",
+ "difference",
+ "once_cell",
+ "pretty_assertions",
+ "regex",
+ "serde_json",
+ "swc_common 0.31.4",
+ "swc_error_reporters 0.15.4",
  "testing_macros",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ html-escape = "0.2.13"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.91"
 string_cache = "0.8.4"
-swc_atoms = "0.4.43"
-swc_core = { version = "0.74", features = [
+swc_atoms = "0.5.3"
+swc_core = { version = "0.75.20", features = [
   "ecma_plugin_transform",
   "ecma_utils",
   "ecma_visit",
@@ -22,7 +22,7 @@ swc_core = { version = "0.74", features = [
 
 [dev-dependencies]
 testing = "0.31"
-swc_core = { version = "0.74", features = [
+swc_core = { version = "0.75.20", features = [
   "testing_transform",
   "ecma_parser",
 ] }


### PR DESCRIPTION
Release train keeps rolling.

Reason for pushing this update is a recently released [fix](https://github.com/swc-project/swc/pull/7243) for swc_ecma_loader. With that fix and this crate, solid-js bundling is working for me.