### PR TITLE
Added compiler options to reduce the size of the resulting WASM

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,12 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[profile.release]
+lto = true
+strip = "symbols"
+opt-level = "z"
+codegen-units = 1
+
 [dependencies]
 convert_case = "0.6"
 once_cell = "1.18"


### PR DESCRIPTION
These options reduce the size of the resulting WASM binary from about 8.84MB, to about 3.08MB